### PR TITLE
Actions: Autolabel issues when opened

### DIFF
--- a/.github/workflows/label-issue.yml
+++ b/.github/workflows/label-issue.yml
@@ -1,0 +1,16 @@
+name: Label issue
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label:
+    name: Label issue
+    runs-on: ubuntu-latest
+    if: github.event.action == 'opened'
+    steps:
+      - name: Label issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo '{"labels": ["CLI"]}' | gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/labels --input -


### PR DESCRIPTION
Adds the label `CLI` to all newly created issues, for consistent project tracking.