### PR TITLE
Change Semmle to GitHub links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo holds binaries for the CodeQL CLI.
 
-[CodeQL overview](https://securitylab.github.com/tools/codeql) | [CodeQL CLI Documentation](https://help.semmle.com/codeql/codeql-cli.html)
+[CodeQL overview](https://securitylab.github.com/tools/codeql/) | [CodeQL CLI Documentation](https://codeql.github.com/docs/codeql-cli/)
 
 # Getting started
 
@@ -10,12 +10,12 @@ This repo holds binaries for the CodeQL CLI.
 2. Find the latest release, select Assets, and download the zip file containing the CLI.
 3. You'll also want to clone https://github.com/github/codeql to get the CodeQL queries and
    libraries. Please take note of the
-   [set-up instructions](https://help.semmle.com/codeql/codeql-cli/procedures/get-started.html)
+   [set-up instructions](https://codeql.github.com/docs/codeql-cli/getting-started-with-the-codeql-cli/)
    for placing it in a location where the CLI can find it.
-4. Read the rest of the [CodeQL CLI documentation](https://help.semmle.com/codeql/codeql-cli.html).
+4. Read the rest of the [CodeQL CLI documentation](https://codeql.github.com/docs/codeql-cli/).
 
 # License
 
-By downloading, you agree to the [GitHub CodeQL Terms & Conditions](https://securitylab.github.com/tools/codeql/license).
+By downloading, you agree to the [GitHub CodeQL Terms & Conditions](https://securitylab.github.com/tools/codeql/license/).
 
 GitHub CodeQL can only be used on codebases that are released under an OSI-approved open source license, or to perform academic research. It can't be used to generate CodeQL databases for or during automated analysis, continuous integration or continuous delivery, whether as part of normal software engineering processes or otherwise. For these uses, [contact the sales team](https://enterprise.github.com/contact).


### PR DESCRIPTION
I have also added a trailing `/` to some of the existing URLs because that is their current redirect target.
(Though if you want I can also omit the trailing backslash for consistency for all URLs here.)