### PR TITLE
Create issue configuration directing to the github/codeql repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report an issue or ask a question about CodeQL
+    url: https://github.com/github/codeql/issues/new/choose
+    about: Please create issues and ask questions in the `github/codeql` repository.


### PR DESCRIPTION
Encourage users to create issues in `github/codeql`.

Follows the format at https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser.